### PR TITLE
Added default to income_period

### DIFF
--- a/docassemble/income/income.py
+++ b/docassemble/income/income.py
@@ -26,6 +26,7 @@ def income_period(index):
         for row in income_period_list():
             if int(index) == int(row[0]):
                 return row[1].lower()
+        return docassemble.base.functions.nice_number(int(index), capitalize=True) + " " + docassemble.base.functions.word("times per year")
     except:
         return ''
     return ''


### PR DESCRIPTION
Just a suggestion.  E.g., sometimes teachers get income 10 times per year, and there is no name for that but it can be a valid period.